### PR TITLE
Refatora a estrutura para permitir habilitar ou desabilitar o plugin do Metabase

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -8,6 +8,10 @@ class Plugin extends \MapasCulturais\Plugin
 {
     function __construct($config = [])
     {
+        $config+= [
+            'enabled' => function() { return true;}
+        ];
+
         parent::__construct($config);
     }
 
@@ -15,7 +19,7 @@ class Plugin extends \MapasCulturais\Plugin
     {
         $app = App::i();
 
-        if (!$app->config['Metabase']['enabled']) {
+        if (!$this->config['enabled']()) {
             return;
         }
 


### PR DESCRIPTION
Esta implementação permite que um plugin do Metabase seja habilitado ou desabilitado dinamicamente por meio da configuração.  
Ao utilizar uma **função anônima**, é possível passar parâmetros personalizados que controlam a ativação do plugin conforme o contexto desejado.

### Exemplo de uso

No arquivo padrão de configuração de plugins:

`docker/common/config.d/plugins.php`

```php
<?php

return [
    'plugins' => [
        'MultipleLocalAuth' => ['namespace' => 'MultipleLocalAuth'],
        'Metabase' => [
            'namespace' => 'Metabase',
            'config' => [
                'enabled' => function() {
                    $app = \MapasCulturais\App::i();

                    if(env('METABASE_CULTURAVIVA_ENABLED', false)) { // Para ativar atravez do .env
                        return true;
                    }

                    if($app->subsite->id == 8) { // para ativar em um determinado subsite
                        return true;
                    }

                    if(get_class($app->view) == 'CulturaViva\Theme') { // para ativar em um determinado tema
                        return true;
                    }
                    
                   return false; // Desativado por padrão
                },
            ]
        ],
    ]
];
```

